### PR TITLE
Fix token parsing + some minor fixes

### DIFF
--- a/backend/asset/copy-objects.go
+++ b/backend/asset/copy-objects.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/ansel1/merry"
+	"github.com/ansel1/merry/v2"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/bcc-code/mediabank-bridge/log"
 	"go.opentelemetry.io/otel"

--- a/backend/asset/ingest.go
+++ b/backend/asset/ingest.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ansel1/merry"
+	"github.com/ansel1/merry/v2"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/mediapackagevod"
 	"github.com/aws/aws-sdk-go-v2/service/s3"

--- a/backend/asset/read-from-s3.go
+++ b/backend/asset/read-from-s3.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"io/ioutil"
 
-	"github.com/ansel1/merry"
+	"github.com/ansel1/merry/v2"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/bcc-code/brunstadtv/backend/auth0"

--- a/backend/cmd/jobs/server/server.go
+++ b/backend/cmd/jobs/server/server.go
@@ -3,7 +3,7 @@ package server
 import (
 	"net/http"
 
-	"github.com/ansel1/merry"
+	"github.com/ansel1/merry/v2"
 	"github.com/bcc-code/brunstadtv/backend/asset"
 	"github.com/bcc-code/brunstadtv/backend/events"
 	"github.com/bcc-code/brunstadtv/backend/maintenance"

--- a/backend/directus/assets.go
+++ b/backend/directus/assets.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/ansel1/merry"
+	"github.com/ansel1/merry/v2"
 	"github.com/go-resty/resty/v2"
 )
 

--- a/backend/directus/client.go
+++ b/backend/directus/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ansel1/merry"
+	"github.com/ansel1/merry/v2"
 	"github.com/go-resty/resty/v2"
 	"go.opencensus.io/trace"
 )

--- a/backend/directus/events.go
+++ b/backend/directus/events.go
@@ -2,12 +2,13 @@ package directus
 
 import (
 	"context"
-	"github.com/ansel1/merry"
+	"strconv"
+
+	"github.com/ansel1/merry/v2"
 	"github.com/bcc-code/mediabank-bridge/log"
 	cevent "github.com/cloudevents/sdk-go/v2/event"
 	"github.com/gin-gonic/gin"
 	"github.com/samber/lo"
-	"strconv"
 )
 
 type Event struct {

--- a/backend/search/filters.go
+++ b/backend/search/filters.go
@@ -2,11 +2,12 @@ package search
 
 import (
 	"fmt"
-	"github.com/ansel1/merry"
-	"github.com/bcc-code/brunstadtv/backend/common"
-	"github.com/samber/lo"
 	"strings"
 	"time"
+
+	"github.com/ansel1/merry/v2"
+	"github.com/bcc-code/brunstadtv/backend/common"
+	"github.com/samber/lo"
 )
 
 func (handler *RequestHandler) getFiltersForCurrentUser() (string, error) {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/99designs/gqlgen v0.17.9
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.8.1
 	github.com/algolia/algoliasearch-client-go/v3 v3.4.0
-	github.com/ansel1/merry v1.6.2
 	github.com/ansel1/merry/v2 v2.0.1
 	github.com/aws/aws-sdk-go-v2 v1.16.4
 	github.com/aws/aws-sdk-go-v2/config v1.15.9

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,6 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNg
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/ansel1/merry v1.5.0/go.mod h1:wUy/yW0JX0ix9GYvUbciq+bi3jW/vlKPlbpI7qdZpOw=
 github.com/ansel1/merry v1.5.1/go.mod h1:wUy/yW0JX0ix9GYvUbciq+bi3jW/vlKPlbpI7qdZpOw=
-github.com/ansel1/merry v1.6.2 h1:0xr40haRrfVzmOH/JVOu7KOKGEI1c/7q5EmgTEbn+Ng=
-github.com/ansel1/merry v1.6.2/go.mod h1:pAcMW+2uxIgpzEON021vMtFsrymREY6faJWiiz1QGVQ=
 github.com/ansel1/merry/v2 v2.0.1 h1:WeiKZdslHPAPFYxTtgX7clC2Vh75NCoWs5OjCZbIA0A=
 github.com/ansel1/merry/v2 v2.0.1/go.mod h1:dD5OhpiPrVkvgseRYd+xgYlx7s6ytU3v9BTTJlDA7FM=
 github.com/ansel1/vespucci/v4 v4.1.1/go.mod h1:zzdrO4IgBfgcGMbGTk/qNGL8JPslmW3nPpcBHKReFYY=


### PR DESCRIPTION
* Members appears to have significantly altered the token format, so this is the fix to make it work here again.
* upgrades all usages of Merry to Merrry/v2
* Invert `IsAnonymous` to `IsAuthenticated` because the default for `bool` on go is `false` meaning that if we somehow manage to not initialize this variable it will be `false` and thus not expose things that should not be exposed