### PR TITLE
Dataloaders load SQLc rows now

### DIFF
--- a/backend/graph/model/asset.go
+++ b/backend/graph/model/asset.go
@@ -10,7 +10,7 @@ import (
 )
 
 // FileFromSQL converts Assetfile rows to the GQL equvivalents
-func FileFromSQL(ctx context.Context, sqlFile sqlc.GetFilesForEpisodesRow) *File {
+func FileFromSQL(ctx context.Context, sqlFile *sqlc.GetFilesForEpisodesRow) *File {
 	var subLang *Language
 	if sqlFile.SubtitleLanguageID.Valid {
 		l := Language(sqlFile.SubtitleLanguageID.String)
@@ -28,8 +28,7 @@ func FileFromSQL(ctx context.Context, sqlFile sqlc.GetFilesForEpisodesRow) *File
 }
 
 // StreamFromSQL converts Assetfile rows to the GQL equvivalents
-func StreamFromSQL(ctx context.Context, sqlStream sqlc.GetStreamsForEpisodesRow) *Stream {
-
+func StreamFromSQL(ctx context.Context, sqlStream *sqlc.GetStreamsForEpisodesRow) *Stream {
 	return &Stream{
 		ID:                strconv.Itoa(int(sqlStream.ID)),
 		URL:               sqlStream.Path, // TODO: Make a full url out of the path

--- a/backend/graph/model/episode.go
+++ b/backend/graph/model/episode.go
@@ -12,7 +12,7 @@ import (
 )
 
 // EpisodeFromSQL coverts a SQL row into an GQL episode type
-func EpisodeFromSQL(ctx context.Context, row sqlc.GetEpisodesWithTranslationsByIDRow) Episode {
+func EpisodeFromSQL(ctx context.Context, row *sqlc.GetEpisodesWithTranslationsByIDRow) *Episode {
 	titleMap := common.LocaleString{}
 	descriptionMap := common.LocaleString{}
 	extraDescriptionMap := common.LocaleString{}
@@ -24,7 +24,7 @@ func EpisodeFromSQL(ctx context.Context, row sqlc.GetEpisodesWithTranslationsByI
 	ginCtx, _ := utils.GinCtx(ctx)
 	languages := user.GetLanguagesFromCtx(ginCtx)
 
-	return Episode{
+	return &Episode{
 		Chapters:         []*Chapter{}, // Currently not supported
 		ID:               fmt.Sprintf("%d", row.ID),
 		Title:            titleMap.Get(languages),

--- a/backend/graph/resolver.go
+++ b/backend/graph/resolver.go
@@ -1,7 +1,6 @@
 package graph
 
 import (
-	gqlmodel "github.com/bcc-code/brunstadtv/backend/graph/model"
 	"github.com/bcc-code/brunstadtv/backend/sqlc"
 	"github.com/graph-gophers/dataloader/v7"
 )
@@ -19,7 +18,7 @@ type Resolver struct {
 
 // BatchLoaders is a collection of GQL dataloaders
 type BatchLoaders struct {
-	EpisodeLoader *dataloader.Loader[int, *gqlmodel.Episode]
-	FilesLoader   *dataloader.Loader[int, []*gqlmodel.File]
-	StreamsLoader *dataloader.Loader[int, []*gqlmodel.Stream]
+	EpisodeLoader *dataloader.Loader[int, *sqlc.GetEpisodesWithTranslationsByIDRow]
+	FilesLoader   *dataloader.Loader[int, []*sqlc.GetFilesForEpisodesRow]
+	StreamsLoader *dataloader.Loader[int, []*sqlc.GetStreamsForEpisodesRow]
 }

--- a/backend/graph/schema.resolvers.go
+++ b/backend/graph/schema.resolvers.go
@@ -18,11 +18,20 @@ import (
 )
 
 func (r *episodeResolver) Streams(ctx context.Context, obj *gqlmodel.Episode) ([]*gqlmodel.Stream, error) {
-	return asset.GetStreamsForEpisode(ctx, r.Resolver.Loaders.StreamsLoader, obj.ID)
+	streams, err := asset.GetStreamsForEpisode(ctx, r.Resolver.Loaders.StreamsLoader, obj.ID)
+	if err != nil {
+		return nil, err
+	}
+	return utils.MapWithCtx(ctx, streams, gqlmodel.StreamFromSQL), nil
 }
 
 func (r *episodeResolver) Files(ctx context.Context, obj *gqlmodel.Episode) ([]*gqlmodel.File, error) {
-	return asset.GetFilesForEpisode(ctx, r.Resolver.Loaders.FilesLoader, obj.ID)
+	files, err := asset.GetFilesForEpisode(ctx, r.Resolver.Loaders.FilesLoader, obj.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.MapWithCtx(ctx, files, gqlmodel.FileFromSQL), nil
 }
 
 func (r *episodeResolver) Season(ctx context.Context, obj *gqlmodel.Episode) (*gqlmodel.Season, error) {
@@ -39,7 +48,12 @@ func (r *queryRootResolver) Episode(ctx context.Context, id string) (*gqlmodel.E
 		return nil, err
 	}
 
-	return episode.GetByID(ctx, r.Resolver.Loaders.EpisodeLoader, int(intID))
+	episode, err := episode.GetByID(ctx, r.Resolver.Loaders.EpisodeLoader, int(intID))
+	if err != nil {
+		return nil, err
+	}
+
+	return gqlmodel.EpisodeFromSQL(ctx, episode), nil
 }
 
 func (r *queryRootResolver) Section(ctx context.Context, id string) (gqlmodel.Section, error) {

--- a/backend/utils/map.go
+++ b/backend/utils/map.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	"context"
+
+	"github.com/samber/lo"
+)
+
+// MapWithCtx performs a lo.Map but adds ctx as the 1st param to the map function and ignores index
+func MapWithCtx[T any, TOut any](ctx context.Context, list []T, f func(context.Context, T) TOut) []TOut {
+	return lo.Map(list, func(element T, _ int) TOut {
+		return f(ctx, element)
+	})
+}


### PR DESCRIPTION
Enabled cache - Cached queries are 2 orders of magnitude faster locally
Also seems to simplify the dependency graph