### PR TITLE
"Id" != "id"

### DIFF
--- a/cms/src/hooks/sync-to-legacy/filters/tags.ts
+++ b/cms/src/hooks/sync-to-legacy/filters/tags.ts
@@ -12,7 +12,7 @@ export async function createEpisodeTag(p, m, c) {
 
     let db = c.database as Knex<any>
 
-    let episode = (await db("episodes").select("*").where("Id", p.episodes_id))[0];
+    let episode = (await db("episodes").select("*").where("id", p.episodes_id))[0];
     let tag_ids = (await db("episodes_tags").select("tags_id").where("episodes_id", p.episodes_id)).map(t => t.tags_id);
     tag_ids.push(p.tags_id.id)
 
@@ -37,8 +37,8 @@ export async function deleteEpisodeTag(p, m, c) {
 
 
     let db = c.database as Knex<any>
-    let tagToDelete = (await db("episodes_tags").select("*").where("Id", p[0]))[0];
-    let episode = (await db("episodes").select("*").where("Id", tagToDelete.episodes_id))[0];
+    let tagToDelete = (await db("episodes_tags").select("*").where("id", p[0]))[0];
+    let episode = (await db("episodes").select("*").where("id", tagToDelete.episodes_id))[0];
     let tag_ids = (await db("episodes_tags").select("tags_id").where("episodes_id", tagToDelete.episodes_id)).map(t => t.tags_id);
 
 


### PR DESCRIPTION
Turns out this was causing errors in Directus and not syncing tags