### PR TITLE
Refactor crowdin/directus handler

### DIFF
--- a/backend/cmd/jobs/main.go
+++ b/backend/cmd/jobs/main.go
@@ -17,44 +17,12 @@ import (
 	"github.com/bcc-code/brunstadtv/backend/utils"
 	"github.com/bcc-code/mediabank-bridge/log"
 	"github.com/gin-gonic/gin"
-	"github.com/go-resty/resty/v2"
 	_ "github.com/lib/pq"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel"
 )
 
 const debugDirectus = false
-
-func initializeDirectusEventHandler(directusClient *resty.Client, searchService *search.Service, crowdinClient *crowdin.Client) *directus.EventHandler {
-	eventHandler := directus.NewEventHandler()
-
-	for _, event := range []string{directus.EventItemsCreate, directus.EventItemsUpdate} {
-		eventHandler.On(event, func(ctx context.Context, collection string, id int) {
-			err := searchService.IndexModel(ctx, collection, id)
-			if err != nil {
-				log.L.Error().Err(err).Msg("failed to index model for search")
-				return
-			}
-
-			directusHandler := directus.NewHandler(directusClient)
-			err = crowdinClient.HandleModelUpdate(ctx, directusHandler, collection, id)
-			if err != nil {
-				log.L.Error().Err(err).Msg("failed to handle model for crowdin")
-				return
-			}
-		})
-	}
-
-	eventHandler.On(directus.EventItemsDelete, func(ctx context.Context, collection string, id int) {
-		err := searchService.DeleteModel(collection, id)
-		if err != nil {
-			log.L.Error().Err(err).Msg("Error occurred when trying to delete model from search index")
-		}
-		crowdinClient.HandleModelDelete(collection, id)
-	})
-
-	return eventHandler
-}
 
 func main() {
 	ctx := context.Background()
@@ -109,8 +77,14 @@ func main() {
 	queries := sqlc.New(db)
 
 	searchService := search.New(db, config.Algolia.AppId, config.Algolia.ApiKey)
-	crowdinClient := crowdin.New(config.Crowdin.Token, crowdin.Config{ProjectIDs: config.Crowdin.ProjectIDs})
-	directusEventHandler := initializeDirectusEventHandler(directusClient, searchService, crowdinClient)
+	directusEventHandler := directus.NewEventHandler()
+	crowdinClient := crowdin.New(config.Crowdin.Token, crowdin.Config{ProjectIDs: config.Crowdin.ProjectIDs}, directus.NewHandler(directusClient))
+
+	directusEventHandler.On([]string{directus.EventItemsCreate, directus.EventItemsUpdate}, searchService.IndexModel)
+	directusEventHandler.On([]string{directus.EventItemsCreate, directus.EventItemsUpdate}, crowdinClient.HandleModelUpdate)
+
+	directusEventHandler.On([]string{directus.EventItemsDelete}, searchService.DeleteModel)
+	directusEventHandler.On([]string{directus.EventItemsDelete}, crowdinClient.HandleModelDelete)
 
 	log.L.Debug().Msg("Set up HTTP server")
 	router := gin.Default()

--- a/backend/crowdin/client.go
+++ b/backend/crowdin/client.go
@@ -25,6 +25,7 @@ type Config struct {
 // Client for crowdin interactions
 type Client struct {
 	c      *resty.Client
+	du     *directus.Handler
 	config Config
 }
 
@@ -39,13 +40,14 @@ func ensureSuccess(res *resty.Response) error {
 }
 
 // New client for requests
-func New(token string, config Config) *Client {
+func New(token string, config Config, directusHandler *directus.Handler) *Client {
 	c := resty.New().
 		SetBaseURL("https://api.crowdin.com/api/v2/").
 		SetAuthToken(token)
 	return &Client{
-		c,
-		config,
+		du:     directusHandler,
+		c:      c,
+		config: config,
 	}
 }
 

--- a/backend/crowdin/events.go
+++ b/backend/crowdin/events.go
@@ -83,12 +83,12 @@ func getTranslationsForItem(ctx context.Context, d *directus.Handler, collection
 }
 
 // HandleModelUpdate for triggering actions on object change
-func (client *Client) HandleModelUpdate(ctx context.Context, directusHandler *directus.Handler, collection string, id int) error {
-	if status, err := getStatusForItem(ctx, directusHandler, collection, id); err != nil || status != "published" {
+func (client *Client) HandleModelUpdate(ctx context.Context, collection string, id int) error {
+	if status, err := getStatusForItem(ctx, client.du, collection, id); err != nil || status != "published" {
 		// Return error, else just ignore if not published
 		return err
 	}
-	translations, err := getTranslationsForItem(ctx, directusHandler, collection, id, "")
+	translations, err := getTranslationsForItem(ctx, client.du, collection, id, "")
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,8 @@ func (client *Client) HandleModelUpdate(ctx context.Context, directusHandler *di
 }
 
 // HandleModelDelete for triggering actions to handle deletion events
-func (client *Client) HandleModelDelete(collection string, id int) {
-	log.L.Debug().Str("collection", collection).Int("id", id).Msg("deleting translations")
+func (client *Client) HandleModelDelete(_ context.Context, collection string, id int) error {
+	log.L.Debug().Str("collection", collection).Int("id", id).Msg("deleting translations - not implemented")
 	// TODO: implement deletion of translations
+	return nil
 }

--- a/backend/search/indexing.go
+++ b/backend/search/indexing.go
@@ -2,6 +2,9 @@ package search
 
 import (
 	"context"
+	"strconv"
+	"strings"
+
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/opt"
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
 	"github.com/ansel1/merry/v2"
@@ -11,8 +14,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/graph-gophers/dataloader/v7"
 	"github.com/samber/lo"
-	"strconv"
-	"strings"
 )
 
 // Reindex every supported collection
@@ -197,7 +198,7 @@ func indexObject[k comparable, t indexable[k]](
 }
 
 // DeleteModel from index by collection and id
-func (service *Service) DeleteModel(collection string, id int) error {
+func (service *Service) DeleteModel(_ context.Context, collection string, id int) error {
 	_, err := service.index.DeleteObject(collection + "-" + strconv.Itoa(id))
 	return err
 }


### PR DESCRIPTION
The dependency is now injected earlier into the crowdin handler and the
directus event handler doesn't need to care about the handler functions
it's executing beyond the signature.

This is in preparation for adding more handlers functions for the
realtime functionality.