### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.json]
+indent_style = space
+indent_size = 2
+
+[{Makefile,go.mod,go.sum,*.go,.gitmodules}]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
This is basically just making sure that all editors we use do the same thing and that "thing" should be as close as we have it now already.

Feel free to add formatting for other file types.
For go, `go fmt` still has the final word on the formatting.

Maybe we should introduce something like that for TS and vue as well?