### PR TITLE
Fix sync-to-legacy not working

### DIFF
--- a/cms/package-lock.json
+++ b/cms/package-lock.json
@@ -1540,7 +1540,7 @@
         "knex-schema-inspector": "2.0.4",
         "lodash": "4.17.21",
         "micromustache": "^8.0.3",
-        "nanoid": "^4.0.0",
+        "nanoid": "^3.3.4",
         "pino": "6.13.3",
         "vue": "3.2.36",
         "vue-i18n": "9.1.10",
@@ -1662,17 +1662,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/@directus/shared/node_modules/nanoid": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
-      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18"
-      }
     },
     "node_modules/@directus/specs": {
       "version": "9.17.4",
@@ -15934,7 +15923,7 @@
         "knex-schema-inspector": "2.0.4",
         "lodash": "4.17.21",
         "micromustache": "^8.0.3",
-        "nanoid": "^4.0.0",
+        "nanoid": "^3.3.4",
         "pino": "6.13.3",
         "vue": "3.2.36",
         "vue-i18n": "9.1.10",
@@ -16006,11 +15995,6 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "nanoid": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
-          "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg=="
         }
       }
     },

--- a/cms/src/hooks/sync-to-legacy/filters/assetstreams.ts
+++ b/cms/src/hooks/sync-to-legacy/filters/assetstreams.ts
@@ -4,9 +4,11 @@ import episodes from '../../../btv';
 import {  VideoUrlEntity } from "@/Database";
 import { ItemsService } from "directus";
 
-
 export async function createAssetstream(p, m, c) {
     let asset = (await c.database("assets").select("*").where("id", p.asset_id))[0];
+
+	console.log("createAssetstream")
+	console.log("legacy_id", asset.legacy_id)
 
     // update it in original
     let patch: Partial<VideoUrlEntity> = {
@@ -60,7 +62,7 @@ export async function updateAssetstream (p, m, c) {
     if (!service) {
         service = assetstreamBeforeUpdate.service;
     }
- 
+
     if (p.type === "hls_cmaf" && p.service.indexOf('mediapackage') !== -1) {
         // Hacky solution for mediapackge to work.
         // The app accepts application/vnd.apple.mpegurl

--- a/cms/src/hooks/sync-to-legacy/filters/assetstreams.ts
+++ b/cms/src/hooks/sync-to-legacy/filters/assetstreams.ts
@@ -5,6 +5,10 @@ import {  VideoUrlEntity } from "@/Database";
 import { ItemsService } from "directus";
 
 export async function createAssetstream(p, m, c) {
+    if (m.collection != "assetstreams") {
+        return
+    }
+
     let asset = (await c.database("assets").select("*").where("id", p.asset_id))[0];
 
 	console.log("createAssetstream")


### PR DESCRIPTION
Probably the most important part is [Downgrade nanoid to 3.3.4](https://github.com/bcc-code/brunstadtv/commit/c3c2e91e712f0a29bf3e3529b604274fd2d7f75d)

Note: this is in PROD, just making a PR for visibility of the fix