### PR TITLE
Implement episode and season count on show

### DIFF
--- a/backend/graph/api/items.resolvers.go
+++ b/backend/graph/api/items.resolvers.go
@@ -137,6 +137,37 @@ func (r *showResolver) Image(ctx context.Context, obj *model.Show, style *model.
 	return e.Images.GetDefault(user.GetLanguagesFromCtx(ginCtx), s), nil
 }
 
+// EpisodeCount is the resolver for the episodeCount field.
+func (r *showResolver) EpisodeCount(ctx context.Context, obj *model.Show) (int, error) {
+	seasonIDs, err := common.GetFromLoaderForKey(ctx, r.FilteredLoaders(ctx).SeasonsLoader, utils.AsInt(obj.ID))
+	if err != nil {
+		return 0, err
+	}
+	el := r.FilteredLoaders(ctx).EpisodesLoader
+	for _, id := range seasonIDs {
+		el.Load(ctx, *id)
+	}
+
+	count := 0
+	for _, id := range seasonIDs {
+		episodeIDs, err := common.GetFromLoaderForKey(ctx, el, *id)
+		if err != nil {
+			return 0, err
+		}
+		count += len(episodeIDs)
+	}
+	return count, nil
+}
+
+// SeasonCount is the resolver for the seasonCount field.
+func (r *showResolver) SeasonCount(ctx context.Context, obj *model.Show) (int, error) {
+	seasonIDs, err := common.GetFromLoaderForKey(ctx, r.FilteredLoaders(ctx).SeasonsLoader, utils.AsInt(obj.ID))
+	if err != nil {
+		return 0, err
+	}
+	return len(seasonIDs), nil
+}
+
 // Seasons is the resolver for the seasons field.
 func (r *showResolver) Seasons(ctx context.Context, obj *model.Show, first *int, offset *int, dir *string) (*model.SeasonPagination, error) {
 	intID, err := strconv.ParseInt(obj.ID, 10, 64)

--- a/backend/graph/api/schema/items.graphqls
+++ b/backend/graph/api/schema/items.graphqls
@@ -12,8 +12,8 @@ type Show {
     image(style: ImageStyle): String @goField(forceResolver: true)
     imageUrl: String
     images: [Image!]!
-    episodeCount: Int!
-    seasonCount: Int!
+    episodeCount: Int! @goField(forceResolver: true)
+    seasonCount: Int! @goField(forceResolver: true)
     seasons(
         first: Int
         offset: Int


### PR DESCRIPTION
One of two possible solutions.
This one: Retrieve episode & season count on request, filtered by permissions as well (cached by role)

Alternative: Total count of related episodes and seasons retrieved when retrieving show (globally cached)

I think this one is the best one for our use case, as long as we don't run into performance issues later.