### PR TITLE
move batch loaders

### DIFF
--- a/backend/asset/loader.go
+++ b/backend/asset/loader.go
@@ -1,6 +1,7 @@
 package asset
 
 import (
+	"github.com/bcc-code/brunstadtv/backend/batchloaders"
 	"github.com/bcc-code/brunstadtv/backend/common"
 	"github.com/bcc-code/brunstadtv/backend/sqlc"
 	"github.com/graph-gophers/dataloader/v7"
@@ -8,14 +9,14 @@ import (
 
 // NewBatchFilesLoader returns a configured batch loader for GQL File
 func NewBatchFilesLoader(queries sqlc.Queries) *dataloader.Loader[int, []*common.File] {
-	return common.NewListBatchLoader(queries.GetFilesForEpisodes, func(row common.File) int {
+	return batchloaders.NewListBatchLoader(queries.GetFilesForEpisodes, func(row common.File) int {
 		return row.EpisodeID
 	})
 }
 
 // NewBatchStreamsLoader returns a configured batch loader for GQL Stream
 func NewBatchStreamsLoader(queries sqlc.Queries) *dataloader.Loader[int, []*common.Stream] {
-	return common.NewListBatchLoader(queries.GetStreamsForEpisodes, func(row common.Stream) int {
+	return batchloaders.NewListBatchLoader(queries.GetStreamsForEpisodes, func(row common.Stream) int {
 		return row.EpisodeID
 	})
 }

--- a/backend/batchloaders/cache.go
+++ b/backend/batchloaders/cache.go
@@ -1,4 +1,4 @@
-package common
+package batchloaders
 
 import (
 	"context"
@@ -38,4 +38,15 @@ func (c *loaderCache[K, V]) Delete(ctx context.Context, key K) bool {
 // Clear clears the entire cache
 func (c *loaderCache[K, V]) Clear() {
 	c.cache = cache.New[K, dataloader.Thunk[V]]()
+}
+
+type memoryCache struct {
+	expiration time.Duration
+}
+
+// WithMemoryCache defines how long a key should live in the cache
+func WithMemoryCache(expiration time.Duration) any {
+	return memoryCache{
+		expiration: expiration,
+	}
 }

--- a/backend/batchloaders/loader.go
+++ b/backend/batchloaders/loader.go
@@ -1,7 +1,8 @@
-package common
+package batchloaders
 
 import (
 	"context"
+	"github.com/bcc-code/brunstadtv/backend/common"
 	"github.com/graph-gophers/dataloader/v7"
 	"go.opentelemetry.io/otel"
 	"time"
@@ -9,33 +10,33 @@ import (
 
 // BatchLoaders contains loaders for the different items
 type BatchLoaders struct {
-	ApplicationLoader           *dataloader.Loader[int, *Application]
+	ApplicationLoader           *dataloader.Loader[int, *common.Application]
 	ApplicationIDFromCodeLoader *dataloader.Loader[string, *int]
-	PageLoader                  *dataloader.Loader[int, *Page]
+	PageLoader                  *dataloader.Loader[int, *common.Page]
 	PageIDFromCodeLoader        *dataloader.Loader[string, *int]
-	SectionLoader               *dataloader.Loader[int, *Section]
+	SectionLoader               *dataloader.Loader[int, *common.Section]
 	SectionsLoader              *dataloader.Loader[int, []*int]
-	CollectionLoader            *dataloader.Loader[int, *Collection]
-	CollectionItemLoader        *dataloader.Loader[int, []*CollectionItem]
-	ShowLoader                  *dataloader.Loader[int, *Show]
-	SeasonLoader                *dataloader.Loader[int, *Season]
-	EpisodeLoader               *dataloader.Loader[int, *Episode]
-	LinkLoader                  *dataloader.Loader[int, *Link]
-	FilesLoader                 *dataloader.Loader[int, []*File]
-	StreamsLoader               *dataloader.Loader[int, []*Stream]
-	EventLoader                 *dataloader.Loader[int, *Event]
-	CalendarEntryLoader         *dataloader.Loader[int, *CalendarEntry]
-	FAQCategoryLoader           *dataloader.Loader[int, *FAQCategory]
-	QuestionLoader              *dataloader.Loader[int, *Question]
+	CollectionLoader            *dataloader.Loader[int, *common.Collection]
+	CollectionItemLoader        *dataloader.Loader[int, []*common.CollectionItem]
+	ShowLoader                  *dataloader.Loader[int, *common.Show]
+	SeasonLoader                *dataloader.Loader[int, *common.Season]
+	EpisodeLoader               *dataloader.Loader[int, *common.Episode]
+	LinkLoader                  *dataloader.Loader[int, *common.Link]
+	FilesLoader                 *dataloader.Loader[int, []*common.File]
+	StreamsLoader               *dataloader.Loader[int, []*common.Stream]
+	EventLoader                 *dataloader.Loader[int, *common.Event]
+	CalendarEntryLoader         *dataloader.Loader[int, *common.CalendarEntry]
+	FAQCategoryLoader           *dataloader.Loader[int, *common.FAQCategory]
+	QuestionLoader              *dataloader.Loader[int, *common.Question]
 	QuestionsLoader             *dataloader.Loader[int, []*int]
-	ProfilesLoader              *dataloader.Loader[string, []*Profile]
-	MessageGroupLoader          *dataloader.Loader[int, *MessageGroup]
+	ProfilesLoader              *dataloader.Loader[string, []*common.Profile]
+	MessageGroupLoader          *dataloader.Loader[int, *common.MessageGroup]
 	// Permissions
-	ShowPermissionLoader    *dataloader.Loader[int, *Permissions[int]]
-	SeasonPermissionLoader  *dataloader.Loader[int, *Permissions[int]]
-	EpisodePermissionLoader *dataloader.Loader[int, *Permissions[int]]
-	PagePermissionLoader    *dataloader.Loader[int, *Permissions[int]]
-	SectionPermissionLoader *dataloader.Loader[int, *Permissions[int]]
+	ShowPermissionLoader    *dataloader.Loader[int, *common.Permissions[int]]
+	SeasonPermissionLoader  *dataloader.Loader[int, *common.Permissions[int]]
+	EpisodePermissionLoader *dataloader.Loader[int, *common.Permissions[int]]
+	PagePermissionLoader    *dataloader.Loader[int, *common.Permissions[int]]
+	SectionPermissionLoader *dataloader.Loader[int, *common.Permissions[int]]
 }
 
 // FilteredLoaders contains loaders that will be filtered by permissions.
@@ -46,13 +47,13 @@ type FilteredLoaders struct {
 	SeasonsLoader           *dataloader.Loader[int, []*int]
 	ShowFilterLoader        *dataloader.Loader[int, *int]
 	SectionsLoader          *dataloader.Loader[int, []*int]
-	CollectionItemsLoader   *dataloader.Loader[int, []*CollectionItem]
+	CollectionItemsLoader   *dataloader.Loader[int, []*common.CollectionItem]
 	CollectionItemIDsLoader *dataloader.Loader[int, []int]
 }
 
 // ProfileLoaders contains loaders per profile
 type ProfileLoaders struct {
-	ProgressLoader *dataloader.Loader[int, *Progress]
+	ProgressLoader *dataloader.Loader[int, *common.Progress]
 }
 
 func getOptions[K comparable, V any](opts ...any) []dataloader.Option[K, V] {
@@ -123,7 +124,7 @@ func NewListBatchLoader[K comparable, V any](
 
 // NewRelationBatchLoader returns a configured batch loader for Lists
 func NewRelationBatchLoader[K comparable, R comparable](
-	factory func(ctx context.Context, ids []R) ([]Relation[K, R], error),
+	factory func(ctx context.Context, ids []R) ([]common.Relation[K, R], error),
 	opts ...any,
 ) *dataloader.Loader[R, []*K] {
 	batchLoadLists := func(ctx context.Context, keys []R) []*dataloader.Result[[]*K] {
@@ -167,7 +168,7 @@ func NewRelationBatchLoader[K comparable, R comparable](
 
 // NewConversionBatchLoader returns a configured batch loader for Lists
 func NewConversionBatchLoader[o comparable, rt comparable](
-	factory func(ctx context.Context, ids []o) ([]Conversion[o, rt], error),
+	factory func(ctx context.Context, ids []o) ([]common.Conversion[o, rt], error),
 	opts ...any,
 ) *dataloader.Loader[o, *rt] {
 	batchLoadLists := func(ctx context.Context, keys []o) []*dataloader.Result[*rt] {
@@ -205,7 +206,7 @@ func NewConversionBatchLoader[o comparable, rt comparable](
 }
 
 // NewBatchLoader returns a configured batch loader for items
-func NewBatchLoader[K comparable, V HasKey[K]](
+func NewBatchLoader[K comparable, V common.HasKey[K]](
 	factory func(ctx context.Context, ids []K) ([]V, error),
 	opts ...any,
 ) *dataloader.Loader[K, *V] {
@@ -260,17 +261,6 @@ func NewCustomBatchLoader[K comparable, V any](
 
 	// Currently we do not want to cache at the GQL level
 	return dataloader.NewBatchedLoader(batchLoadItems, options...)
-}
-
-type memoryCache struct {
-	expiration time.Duration
-}
-
-// WithMemoryCache defines how long a key should live in the cache
-func WithMemoryCache(expiration time.Duration) any {
-	return memoryCache{
-		expiration: expiration,
-	}
 }
 
 // GetFromLoaderByID returns the object from the loader

--- a/backend/graph/admin/resolver.go
+++ b/backend/graph/admin/resolver.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"context"
 	"database/sql"
+	"github.com/bcc-code/brunstadtv/backend/batchloaders"
 	"github.com/bcc-code/brunstadtv/backend/common"
 	"github.com/bcc-code/brunstadtv/backend/graph/admin/model"
 	"github.com/bcc-code/brunstadtv/backend/items/collection"
@@ -17,7 +18,7 @@ import (
 type Resolver struct {
 	DB      *sql.DB
 	Queries *sqlc.Queries
-	Loaders *common.BatchLoaders
+	Loaders *batchloaders.BatchLoaders
 }
 
 func (r *previewResolver) getItemsForFilter(ctx context.Context, col string, filter common.Filter) ([]*model.CollectionItem, error) {
@@ -36,7 +37,7 @@ func (r *previewResolver) getItemsForFilter(ctx context.Context, col string, fil
 
 	switch col {
 	case "shows":
-		shows, err := common.GetManyFromLoader(ctx, r.Loaders.ShowLoader, ids)
+		shows, err := batchloaders.GetManyFromLoader(ctx, r.Loaders.ShowLoader, ids)
 		items = lo.Map(shows, func(s *common.Show, _ int) *model.CollectionItem {
 			return &model.CollectionItem{
 				ID:    strconv.Itoa(s.ID),
@@ -47,7 +48,7 @@ func (r *previewResolver) getItemsForFilter(ctx context.Context, col string, fil
 			return nil, err
 		}
 	case "seasons":
-		shows, err := common.GetManyFromLoader(ctx, r.Loaders.SeasonLoader, ids)
+		shows, err := batchloaders.GetManyFromLoader(ctx, r.Loaders.SeasonLoader, ids)
 		items = lo.Map(shows, func(s *common.Season, _ int) *model.CollectionItem {
 			return &model.CollectionItem{
 				ID:    strconv.Itoa(s.ID),
@@ -58,7 +59,7 @@ func (r *previewResolver) getItemsForFilter(ctx context.Context, col string, fil
 			return nil, err
 		}
 	case "episodes":
-		shows, err := common.GetManyFromLoader(ctx, r.Loaders.EpisodeLoader, ids)
+		shows, err := batchloaders.GetManyFromLoader(ctx, r.Loaders.EpisodeLoader, ids)
 		items = lo.Map(shows, func(s *common.Episode, _ int) *model.CollectionItem {
 			return &model.CollectionItem{
 				ID:    strconv.Itoa(s.ID),

--- a/backend/graph/api/calendar-resolver.go
+++ b/backend/graph/api/calendar-resolver.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"context"
+	"github.com/bcc-code/brunstadtv/backend/batchloaders"
 	"github.com/bcc-code/brunstadtv/backend/common"
 	"github.com/bcc-code/brunstadtv/backend/graph/api/model"
 	"github.com/bcc-code/brunstadtv/backend/utils"
@@ -15,7 +16,7 @@ func getForPeriod[k comparable, t any](ctx context.Context, loader *dataloader.L
 	if err != nil {
 		return nil, err
 	}
-	items, err := common.GetManyFromLoader(ctx, loader, ids)
+	items, err := batchloaders.GetManyFromLoader(ctx, loader, ids)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/graph/api/collection-resolver.go
+++ b/backend/graph/api/collection-resolver.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"context"
+	"github.com/bcc-code/brunstadtv/backend/batchloaders"
 	"github.com/bcc-code/brunstadtv/backend/common"
 	"github.com/bcc-code/brunstadtv/backend/graph/api/model"
 	"github.com/bcc-code/brunstadtv/backend/items/collection"
@@ -9,7 +10,7 @@ import (
 	"strconv"
 )
 
-func preloadLoaders(ctx context.Context, loaders *common.BatchLoaders, entries []collection.Entry) {
+func preloadLoaders(ctx context.Context, loaders *batchloaders.BatchLoaders, entries []collection.Entry) {
 	for _, e := range entries {
 		switch e.Type {
 		case "show":
@@ -26,7 +27,7 @@ func preloadLoaders(ctx context.Context, loaders *common.BatchLoaders, entries [
 	}
 }
 
-func sectionCollectionEntryResolver(ctx context.Context, loaders *common.BatchLoaders, filteredLoaders *common.FilteredLoaders, section *common.Section, first *int, offset *int) (*utils.PaginationResult[*model.SectionItem], error) {
+func sectionCollectionEntryResolver(ctx context.Context, loaders *batchloaders.BatchLoaders, filteredLoaders *batchloaders.FilteredLoaders, section *common.Section, first *int, offset *int) (*utils.PaginationResult[*model.SectionItem], error) {
 	if !section.CollectionID.Valid {
 		return &utils.PaginationResult[*model.SectionItem]{}, nil
 	}
@@ -45,31 +46,31 @@ func sectionCollectionEntryResolver(ctx context.Context, loaders *common.BatchLo
 		var item *model.SectionItem
 		switch e.Type {
 		case "page":
-			i, err := common.GetFromLoaderByID(ctx, loaders.PageLoader, e.ID)
+			i, err := batchloaders.GetFromLoaderByID(ctx, loaders.PageLoader, e.ID)
 			if err != nil {
 				return nil, err
 			}
 			item = model.PageSectionItemFrom(ctx, i, e.Sort, section.Style)
 		case "show":
-			i, err := common.GetFromLoaderByID(ctx, loaders.ShowLoader, e.ID)
+			i, err := batchloaders.GetFromLoaderByID(ctx, loaders.ShowLoader, e.ID)
 			if err != nil {
 				return nil, err
 			}
 			item = model.ShowSectionItemFrom(ctx, i, e.Sort, section.Style)
 		case "season":
-			i, err := common.GetFromLoaderByID(ctx, loaders.SeasonLoader, e.ID)
+			i, err := batchloaders.GetFromLoaderByID(ctx, loaders.SeasonLoader, e.ID)
 			if err != nil {
 				return nil, err
 			}
 			item = model.SeasonSectionItemFrom(ctx, i, e.Sort, section.Style)
 		case "episode":
-			i, err := common.GetFromLoaderByID(ctx, loaders.EpisodeLoader, e.ID)
+			i, err := batchloaders.GetFromLoaderByID(ctx, loaders.EpisodeLoader, e.ID)
 			if err != nil {
 				return nil, err
 			}
 			item = model.EpisodeSectionItemFrom(ctx, i, e.Sort, section.Style)
 		case "link":
-			i, err := common.GetFromLoaderByID(ctx, loaders.LinkLoader, e.ID)
+			i, err := batchloaders.GetFromLoaderByID(ctx, loaders.LinkLoader, e.ID)
 			if err != nil {
 				return nil, err
 			}
@@ -88,7 +89,7 @@ func sectionCollectionEntryResolver(ctx context.Context, loaders *common.BatchLo
 	}, nil
 }
 
-func collectionEntryResolver(ctx context.Context, loaders *common.BatchLoaders, filteredLoaders *common.FilteredLoaders, collectionId int, first *int, offset *int) (*utils.PaginationResult[model.CollectionItem], error) {
+func collectionEntryResolver(ctx context.Context, loaders *batchloaders.BatchLoaders, filteredLoaders *batchloaders.FilteredLoaders, collectionId int, first *int, offset *int) (*utils.PaginationResult[model.CollectionItem], error) {
 	entries, err := collection.GetCollectionEntries(ctx, loaders, filteredLoaders, collectionId)
 	if err != nil {
 		return nil, err
@@ -103,25 +104,25 @@ func collectionEntryResolver(ctx context.Context, loaders *common.BatchLoaders, 
 		var item model.CollectionItem
 		switch e.Type {
 		case "page":
-			i, err := common.GetFromLoaderByID(ctx, loaders.PageLoader, e.ID)
+			i, err := batchloaders.GetFromLoaderByID(ctx, loaders.PageLoader, e.ID)
 			if err != nil {
 				return nil, err
 			}
 			item = model.PageItemFrom(ctx, i, e.Sort)
 		case "show":
-			i, err := common.GetFromLoaderByID(ctx, loaders.ShowLoader, e.ID)
+			i, err := batchloaders.GetFromLoaderByID(ctx, loaders.ShowLoader, e.ID)
 			if err != nil {
 				return nil, err
 			}
 			item = model.ShowItemFrom(ctx, i, e.Sort)
 		case "season":
-			i, err := common.GetFromLoaderByID(ctx, loaders.SeasonLoader, e.ID)
+			i, err := batchloaders.GetFromLoaderByID(ctx, loaders.SeasonLoader, e.ID)
 			if err != nil {
 				return nil, err
 			}
 			item = model.SeasonItemFrom(ctx, i, e.Sort)
 		case "episode":
-			i, err := common.GetFromLoaderByID(ctx, loaders.EpisodeLoader, e.ID)
+			i, err := batchloaders.GetFromLoaderByID(ctx, loaders.EpisodeLoader, e.ID)
 			if err != nil {
 				return nil, err
 			}
@@ -149,7 +150,7 @@ func collectionItemResolverFromCollection(ctx context.Context, r *Resolver, id s
 func sectionCollectionItemResolver(ctx context.Context, r *Resolver, id string, first *int, offset *int) (*model.SectionItemPagination, error) {
 	int64ID, _ := strconv.ParseInt(id, 10, 32)
 
-	section, err := common.GetFromLoaderByID(ctx, r.Loaders.SectionLoader, int(int64ID))
+	section, err := batchloaders.GetFromLoaderByID(ctx, r.Loaders.SectionLoader, int(int64ID))
 	if err != nil {
 		return nil, err
 	}

--- a/backend/graph/api/items.resolvers.go
+++ b/backend/graph/api/items.resolvers.go
@@ -5,9 +5,9 @@ package graph
 
 import (
 	"context"
+	"github.com/bcc-code/brunstadtv/backend/batchloaders"
 	"strconv"
 
-	"github.com/bcc-code/brunstadtv/backend/common"
 	"github.com/bcc-code/brunstadtv/backend/graph/api/generated"
 	"github.com/bcc-code/brunstadtv/backend/graph/api/model"
 	"github.com/bcc-code/brunstadtv/backend/items/show"
@@ -16,7 +16,7 @@ import (
 
 // Image is the resolver for the image field.
 func (r *episodeResolver) Image(ctx context.Context, obj *model.Episode, style *model.ImageStyle) (*string, error) {
-	e, err := common.GetFromLoaderByID(ctx, r.Loaders.EpisodeLoader, utils.AsInt(obj.ID))
+	e, err := batchloaders.GetFromLoaderByID(ctx, r.Loaders.EpisodeLoader, utils.AsInt(obj.ID))
 	if err != nil {
 		return nil, err
 	}
@@ -26,7 +26,7 @@ func (r *episodeResolver) Image(ctx context.Context, obj *model.Episode, style *
 // Streams is the resolver for the streams field.
 func (r *episodeResolver) Streams(ctx context.Context, obj *model.Episode) ([]*model.Stream, error) {
 	intID, _ := strconv.ParseInt(obj.ID, 10, 32)
-	streams, err := common.GetFromLoaderForKey(ctx, r.Resolver.Loaders.StreamsLoader, int(intID))
+	streams, err := batchloaders.GetFromLoaderForKey(ctx, r.Resolver.Loaders.StreamsLoader, int(intID))
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func (r *episodeResolver) Files(ctx context.Context, obj *model.Episode) ([]*mod
 		return nil, err
 	}
 
-	files, err := common.GetFromLoaderForKey(ctx, r.Resolver.Loaders.FilesLoader, int(intID))
+	files, err := batchloaders.GetFromLoaderForKey(ctx, r.Resolver.Loaders.FilesLoader, int(intID))
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (r *episodeResolver) Progress(ctx context.Context, obj *model.Episode) (*in
 	if profileLoaders == nil {
 		return nil, nil
 	}
-	progress, err := common.GetFromLoaderByID(ctx, profileLoaders.ProgressLoader, utils.AsInt(obj.ID))
+	progress, err := batchloaders.GetFromLoaderByID(ctx, profileLoaders.ProgressLoader, utils.AsInt(obj.ID))
 	if err != nil || progress == nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (r *episodeResolver) Progress(ctx context.Context, obj *model.Episode) (*in
 
 // Image is the resolver for the image field.
 func (r *seasonResolver) Image(ctx context.Context, obj *model.Season, style *model.ImageStyle) (*string, error) {
-	e, err := common.GetFromLoaderByID(ctx, r.Loaders.SeasonLoader, utils.AsInt(obj.ID))
+	e, err := batchloaders.GetFromLoaderByID(ctx, r.Loaders.SeasonLoader, utils.AsInt(obj.ID))
 	if err != nil {
 		return nil, err
 	}
@@ -105,14 +105,14 @@ func (r *seasonResolver) Episodes(ctx context.Context, obj *model.Season, first 
 		return nil, err
 	}
 
-	itemIDs, err := common.GetFromLoaderForKey(ctx, r.FilteredLoaders(ctx).EpisodesLoader, int(intID))
+	itemIDs, err := batchloaders.GetFromLoaderForKey(ctx, r.FilteredLoaders(ctx).EpisodesLoader, int(intID))
 	if err != nil {
 		return nil, err
 	}
 
 	page := utils.Paginate(itemIDs, first, offset, dir)
 
-	episodes, err := common.GetManyFromLoader(ctx, r.Loaders.EpisodeLoader, utils.PointerIntArrayToIntArray(page.Items))
+	episodes, err := batchloaders.GetManyFromLoader(ctx, r.Loaders.EpisodeLoader, utils.PointerIntArrayToIntArray(page.Items))
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (r *seasonResolver) Episodes(ctx context.Context, obj *model.Season, first 
 
 // Image is the resolver for the image field.
 func (r *showResolver) Image(ctx context.Context, obj *model.Show, style *model.ImageStyle) (*string, error) {
-	e, err := common.GetFromLoaderByID(ctx, r.Loaders.ShowLoader, utils.AsInt(obj.ID))
+	e, err := batchloaders.GetFromLoaderByID(ctx, r.Loaders.ShowLoader, utils.AsInt(obj.ID))
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func (r *showResolver) Image(ctx context.Context, obj *model.Show, style *model.
 
 // EpisodeCount is the resolver for the episodeCount field.
 func (r *showResolver) EpisodeCount(ctx context.Context, obj *model.Show) (int, error) {
-	seasonIDs, err := common.GetFromLoaderForKey(ctx, r.FilteredLoaders(ctx).SeasonsLoader, utils.AsInt(obj.ID))
+	seasonIDs, err := batchloaders.GetFromLoaderForKey(ctx, r.FilteredLoaders(ctx).SeasonsLoader, utils.AsInt(obj.ID))
 	if err != nil {
 		return 0, err
 	}
@@ -147,7 +147,7 @@ func (r *showResolver) EpisodeCount(ctx context.Context, obj *model.Show) (int, 
 
 	count := 0
 	for _, id := range seasonIDs {
-		episodeIDs, err := common.GetFromLoaderForKey(ctx, el, *id)
+		episodeIDs, err := batchloaders.GetFromLoaderForKey(ctx, el, *id)
 		if err != nil {
 			return 0, err
 		}
@@ -158,7 +158,7 @@ func (r *showResolver) EpisodeCount(ctx context.Context, obj *model.Show) (int, 
 
 // SeasonCount is the resolver for the seasonCount field.
 func (r *showResolver) SeasonCount(ctx context.Context, obj *model.Show) (int, error) {
-	seasonIDs, err := common.GetFromLoaderForKey(ctx, r.FilteredLoaders(ctx).SeasonsLoader, utils.AsInt(obj.ID))
+	seasonIDs, err := batchloaders.GetFromLoaderForKey(ctx, r.FilteredLoaders(ctx).SeasonsLoader, utils.AsInt(obj.ID))
 	if err != nil {
 		return 0, err
 	}
@@ -172,14 +172,14 @@ func (r *showResolver) Seasons(ctx context.Context, obj *model.Show, first *int,
 		return nil, err
 	}
 
-	itemIDs, err := common.GetFromLoaderForKey(ctx, r.FilteredLoaders(ctx).SeasonsLoader, int(intID))
+	itemIDs, err := batchloaders.GetFromLoaderForKey(ctx, r.FilteredLoaders(ctx).SeasonsLoader, int(intID))
 	if err != nil {
 		return nil, err
 	}
 
 	page := utils.Paginate(itemIDs, first, offset, dir)
 
-	seasons, err := common.GetManyFromLoader(ctx, r.Loaders.SeasonLoader, utils.PointerIntArrayToIntArray(page.Items))
+	seasons, err := batchloaders.GetManyFromLoader(ctx, r.Loaders.SeasonLoader, utils.PointerIntArrayToIntArray(page.Items))
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +193,7 @@ func (r *showResolver) Seasons(ctx context.Context, obj *model.Show, first *int,
 
 // DefaultEpisode is the resolver for the defaultEpisode field.
 func (r *showResolver) DefaultEpisode(ctx context.Context, obj *model.Show) (*model.Episode, error) {
-	s, err := common.GetFromLoaderByID(ctx, r.Loaders.ShowLoader, utils.AsInt(obj.ID))
+	s, err := batchloaders.GetFromLoaderByID(ctx, r.Loaders.ShowLoader, utils.AsInt(obj.ID))
 	if err != nil {
 		return nil, err
 	}

--- a/backend/graph/api/pages.resolvers.go
+++ b/backend/graph/api/pages.resolvers.go
@@ -5,9 +5,9 @@ package graph
 
 import (
 	"context"
+	"github.com/bcc-code/brunstadtv/backend/batchloaders"
 	"strconv"
 
-	"github.com/bcc-code/brunstadtv/backend/common"
 	"github.com/bcc-code/brunstadtv/backend/graph/api/generated"
 	"github.com/bcc-code/brunstadtv/backend/graph/api/model"
 	"github.com/bcc-code/brunstadtv/backend/utils"
@@ -56,7 +56,7 @@ func (r *labelSectionResolver) Items(ctx context.Context, obj *model.LabelSectio
 
 // Messages is the resolver for the messages field.
 func (r *messageSectionResolver) Messages(ctx context.Context, obj *model.MessageSection) ([]*model.Message, error) {
-	s, err := common.GetFromLoaderByID(ctx, r.Loaders.SectionLoader, utils.AsInt(obj.ID))
+	s, err := batchloaders.GetFromLoaderByID(ctx, r.Loaders.SectionLoader, utils.AsInt(obj.ID))
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func (r *messageSectionResolver) Messages(ctx context.Context, obj *model.Messag
 
 // Image is the resolver for the image field.
 func (r *pageResolver) Image(ctx context.Context, obj *model.Page, style *model.ImageStyle) (*string, error) {
-	e, err := common.GetFromLoaderByID(ctx, r.Loaders.PageLoader, utils.AsInt(obj.ID))
+	e, err := batchloaders.GetFromLoaderByID(ctx, r.Loaders.PageLoader, utils.AsInt(obj.ID))
 	if err != nil {
 		return nil, err
 	}
@@ -79,14 +79,14 @@ func (r *pageResolver) Sections(ctx context.Context, obj *model.Page, first *int
 		return nil, err
 	}
 
-	itemIDs, err := common.GetFromLoaderForKey(ctx, r.FilteredLoaders(ctx).SectionsLoader, int(intID))
+	itemIDs, err := batchloaders.GetFromLoaderForKey(ctx, r.FilteredLoaders(ctx).SectionsLoader, int(intID))
 	if err != nil {
 		return nil, err
 	}
 
 	page := utils.Paginate(itemIDs, first, offset, nil)
 
-	sections, err := common.GetManyFromLoader(ctx, r.Loaders.SectionLoader, utils.PointerIntArrayToIntArray(page.Items))
+	sections, err := batchloaders.GetManyFromLoader(ctx, r.Loaders.SectionLoader, utils.PointerIntArrayToIntArray(page.Items))
 	if err != nil {
 		return nil, err
 	}

--- a/backend/graph/api/resolver.go
+++ b/backend/graph/api/resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/99designs/gqlgen/graphql"
+	"github.com/bcc-code/brunstadtv/backend/batchloaders"
 	"github.com/bcc-code/brunstadtv/backend/graph/api/model"
 	"github.com/bcc-code/brunstadtv/backend/memorycache"
 	"gopkg.in/guregu/null.v4"
@@ -33,9 +34,9 @@ import (
 // It contains references to all external services and config
 type Resolver struct {
 	Queries         *sqlc.Queries
-	Loaders         *common.BatchLoaders
-	FilteredLoaders func(ctx context.Context) *common.FilteredLoaders
-	ProfileLoaders  func(ctx context.Context) *common.ProfileLoaders
+	Loaders         *batchloaders.BatchLoaders
+	FilteredLoaders func(ctx context.Context) *batchloaders.FilteredLoaders
+	ProfileLoaders  func(ctx context.Context) *batchloaders.ProfileLoaders
 	SearchService   *search.Service
 	URLSigner       *signing.Signer
 	APIConfig       apiConfig
@@ -169,7 +170,7 @@ type itemLoaders[k comparable, t any] struct {
 func resolverFor[k comparable, t any, r any](ctx context.Context, loaders *itemLoaders[k, t], id k, converter func(context.Context, *t) r) (res r, err error) {
 	ctx, span := otel.Tracer("resolver").Start(ctx, "item")
 	defer span.End()
-	obj, err := common.GetFromLoaderByID(ctx, loaders.Item, id)
+	obj, err := batchloaders.GetFromLoaderByID(ctx, loaders.Item, id)
 	if err != nil {
 		return res, err
 	}
@@ -200,7 +201,7 @@ func resolverForIntID[t any, r any](ctx context.Context, loaders *itemLoaders[in
 func itemsResolverFor[k comparable, kr comparable, t any, r any](ctx context.Context, loaders *itemLoaders[k, t], listLoader *dataloader.Loader[kr, []*k], id kr, converter func(context.Context, *t) r) ([]r, error) {
 	ctx, span := otel.Tracer("resolver").Start(ctx, "items")
 	defer span.End()
-	itemIds, err := common.GetFromLoaderForKey(ctx, listLoader, id)
+	itemIds, err := batchloaders.GetFromLoaderForKey(ctx, listLoader, id)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func itemsResolverFor[k comparable, kr comparable, t any, r any](ctx context.Con
 		return *i
 	})
 
-	items, err := common.GetManyFromLoader(ctx, loaders.Item, ids)
+	items, err := batchloaders.GetManyFromLoader(ctx, loaders.Item, ids)
 
 	return utils.MapWithCtx(ctx, items, converter), err
 }
@@ -298,7 +299,7 @@ func resolveMessageSection(ctx context.Context, r *messageSectionResolver, s *co
 		}
 	}
 
-	group, err := common.GetFromLoaderByID(ctx, r.Loaders.MessageGroupLoader, int(s.MessageID.Int64))
+	group, err := batchloaders.GetFromLoaderByID(ctx, r.Loaders.MessageGroupLoader, int(s.MessageID.Int64))
 	if err != nil {
 		return nil, err
 	}

--- a/backend/graph/api/schema.resolvers.go
+++ b/backend/graph/api/schema.resolvers.go
@@ -5,6 +5,7 @@ package graph
 
 import (
 	"context"
+	"github.com/bcc-code/brunstadtv/backend/batchloaders"
 	"strconv"
 	"time"
 
@@ -121,7 +122,7 @@ func (r *queryRootResolver) Page(ctx context.Context, id *string, code *string) 
 		}, *id, model.PageFrom)
 	}
 	if code != nil {
-		intID, err := common.GetFromLoaderByID(ctx, r.Loaders.PageIDFromCodeLoader, *code)
+		intID, err := batchloaders.GetFromLoaderByID(ctx, r.Loaders.PageIDFromCodeLoader, *code)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/graph/public/schema.resolvers.go
+++ b/backend/graph/public/schema.resolvers.go
@@ -5,10 +5,10 @@ package graph
 
 import (
 	"context"
+	"github.com/bcc-code/brunstadtv/backend/batchloaders"
 	"strconv"
 
 	merry "github.com/ansel1/merry/v2"
-	"github.com/bcc-code/brunstadtv/backend/common"
 	"github.com/bcc-code/brunstadtv/backend/graph/public/generated"
 	"github.com/bcc-code/brunstadtv/backend/graph/public/model"
 	"github.com/bcc-code/brunstadtv/backend/version"
@@ -17,7 +17,7 @@ import (
 // Episode is the resolver for the episode field.
 func (r *queryRootResolver) Episode(ctx context.Context, id string) (*model.Episode, error) {
 	intID, _ := strconv.ParseInt(id, 10, 64)
-	item, err := common.GetFromLoaderByID(ctx, r.Loaders.EpisodeLoader, int(intID))
+	item, err := batchloaders.GetFromLoaderByID(ctx, r.Loaders.EpisodeLoader, int(intID))
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (r *queryRootResolver) Episode(ctx context.Context, id string) (*model.Epis
 // Season is the resolver for the season field.
 func (r *queryRootResolver) Season(ctx context.Context, id string) (*model.Season, error) {
 	intID, _ := strconv.ParseInt(id, 10, 64)
-	item, err := common.GetFromLoaderByID(ctx, r.Loaders.SeasonLoader, int(intID))
+	item, err := batchloaders.GetFromLoaderByID(ctx, r.Loaders.SeasonLoader, int(intID))
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func (r *queryRootResolver) Season(ctx context.Context, id string) (*model.Seaso
 // Show is the resolver for the show field.
 func (r *queryRootResolver) Show(ctx context.Context, id string) (*model.Show, error) {
 	intID, _ := strconv.ParseInt(id, 10, 64)
-	item, err := common.GetFromLoaderByID(ctx, r.Loaders.ShowLoader, int(intID))
+	item, err := batchloaders.GetFromLoaderByID(ctx, r.Loaders.ShowLoader, int(intID))
 	if err != nil {
 		return nil, err
 	}

--- a/backend/items/collection/loader.go
+++ b/backend/items/collection/loader.go
@@ -3,6 +3,7 @@ package collection
 import (
 	"context"
 	"database/sql"
+	"github.com/bcc-code/brunstadtv/backend/batchloaders"
 	"strings"
 
 	"github.com/bcc-code/brunstadtv/backend/common"
@@ -14,7 +15,7 @@ import (
 
 // NewItemListBatchLoader returns a configured batch loader for collection-items
 func NewItemListBatchLoader(queries sqlc.Queries) *dataloader.Loader[int, []*common.CollectionItem] {
-	return common.NewListBatchLoader(queries.GetItemsForCollections, func(row common.CollectionItem) int {
+	return batchloaders.NewListBatchLoader(queries.GetItemsForCollections, func(row common.CollectionItem) int {
 		return row.CollectionID
 	})
 }
@@ -85,15 +86,15 @@ func collectionToType(collection string) common.ItemType {
 }
 
 // GetCollectionEntries returns entries for the specified collection
-func GetCollectionEntries(ctx context.Context, loaders *common.BatchLoaders, filteredLoaders *common.FilteredLoaders, collectionId int) ([]Entry, error) {
-	col, err := common.GetFromLoaderByID(ctx, loaders.CollectionLoader, collectionId)
+func GetCollectionEntries(ctx context.Context, loaders *batchloaders.BatchLoaders, filteredLoaders *batchloaders.FilteredLoaders, collectionId int) ([]Entry, error) {
+	col, err := batchloaders.GetFromLoaderByID(ctx, loaders.CollectionLoader, collectionId)
 	if err != nil {
 		return nil, err
 	}
 
 	switch col.Type {
 	case "select":
-		items, err := common.GetFromLoaderForKey(ctx, filteredLoaders.CollectionItemsLoader, col.ID)
+		items, err := batchloaders.GetFromLoaderForKey(ctx, filteredLoaders.CollectionItemsLoader, col.ID)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/items/episode/loader.go
+++ b/backend/items/episode/loader.go
@@ -1,6 +1,7 @@
 package episode
 
 import (
+	"github.com/bcc-code/brunstadtv/backend/batchloaders"
 	"github.com/bcc-code/brunstadtv/backend/common"
 	"github.com/bcc-code/brunstadtv/backend/sqlc"
 	"github.com/graph-gophers/dataloader/v7"
@@ -8,12 +9,12 @@ import (
 
 // NewBatchLoader returns a configured batch loader for episodes
 func NewBatchLoader(queries sqlc.Queries) *dataloader.Loader[int, *common.Episode] {
-	return common.NewBatchLoader(queries.GetEpisodes)
+	return batchloaders.NewBatchLoader(queries.GetEpisodes)
 }
 
 // NewPermissionLoader returns a loader for permissions
 func NewPermissionLoader(queries sqlc.Queries) *dataloader.Loader[int, *common.Permissions[int]] {
-	return common.NewCustomBatchLoader(queries.GetPermissionsForEpisodes, func(i common.Permissions[int]) int {
+	return batchloaders.NewCustomBatchLoader(queries.GetPermissionsForEpisodes, func(i common.Permissions[int]) int {
 		return i.ItemID
 	})
 }

--- a/backend/items/page/loader.go
+++ b/backend/items/page/loader.go
@@ -1,6 +1,7 @@
 package page
 
 import (
+	"github.com/bcc-code/brunstadtv/backend/batchloaders"
 	"github.com/bcc-code/brunstadtv/backend/common"
 	"github.com/bcc-code/brunstadtv/backend/sqlc"
 	"github.com/graph-gophers/dataloader/v7"
@@ -8,7 +9,7 @@ import (
 
 // NewPermissionLoader returns a loader for permissions
 func NewPermissionLoader(queries sqlc.Queries) *dataloader.Loader[int, *common.Permissions[int]] {
-	return common.NewCustomBatchLoader(queries.GetPermissionsForPages, func(i common.Permissions[int]) int {
+	return batchloaders.NewCustomBatchLoader(queries.GetPermissionsForPages, func(i common.Permissions[int]) int {
 		return i.ItemID
 	})
 }

--- a/backend/items/season/loader.go
+++ b/backend/items/season/loader.go
@@ -1,6 +1,7 @@
 package season
 
 import (
+	"github.com/bcc-code/brunstadtv/backend/batchloaders"
 	"github.com/bcc-code/brunstadtv/backend/common"
 	"github.com/bcc-code/brunstadtv/backend/sqlc"
 	"github.com/graph-gophers/dataloader/v7"
@@ -8,12 +9,12 @@ import (
 
 // NewBatchLoader returns a configured batch loader for seasons
 func NewBatchLoader(queries sqlc.Queries) *dataloader.Loader[int, *common.Season] {
-	return common.NewBatchLoader(queries.GetSeasons)
+	return batchloaders.NewBatchLoader(queries.GetSeasons)
 }
 
 // NewPermissionLoader returns a loader for permissions
 func NewPermissionLoader(queries sqlc.Queries) *dataloader.Loader[int, *common.Permissions[int]] {
-	return common.NewCustomBatchLoader(queries.GetPermissionsForSeasons, func(i common.Permissions[int]) int {
+	return batchloaders.NewCustomBatchLoader(queries.GetPermissionsForSeasons, func(i common.Permissions[int]) int {
 		return i.ItemID
 	})
 }

--- a/backend/items/section/loader.go
+++ b/backend/items/section/loader.go
@@ -1,6 +1,7 @@
 package section
 
 import (
+	"github.com/bcc-code/brunstadtv/backend/batchloaders"
 	"github.com/bcc-code/brunstadtv/backend/common"
 	"github.com/bcc-code/brunstadtv/backend/sqlc"
 	"github.com/graph-gophers/dataloader/v7"
@@ -8,7 +9,7 @@ import (
 
 // NewPermissionLoader returns a loader for permissions
 func NewPermissionLoader(queries sqlc.Queries) *dataloader.Loader[int, *common.Permissions[int]] {
-	return common.NewCustomBatchLoader(queries.GetPermissionsForSections, func(i common.Permissions[int]) int {
+	return batchloaders.NewCustomBatchLoader(queries.GetPermissionsForSections, func(i common.Permissions[int]) int {
 		return i.ItemID
 	})
 }

--- a/backend/items/show/defaults.go
+++ b/backend/items/show/defaults.go
@@ -2,15 +2,16 @@ package show
 
 import (
 	"context"
+	"github.com/bcc-code/brunstadtv/backend/batchloaders"
 	"github.com/bcc-code/brunstadtv/backend/common"
 	"github.com/samber/lo"
 )
 
-func getEpisodeIDFromSeason(ctx context.Context, loaders *common.FilteredLoaders, sID *int, first bool) (*int, error) {
+func getEpisodeIDFromSeason(ctx context.Context, loaders *batchloaders.FilteredLoaders, sID *int, first bool) (*int, error) {
 	if sID == nil {
 		return nil, nil
 	}
-	eIDs, err := common.GetFromLoaderForKey(ctx, loaders.EpisodesLoader, *sID)
+	eIDs, err := batchloaders.GetFromLoaderForKey(ctx, loaders.EpisodesLoader, *sID)
 	if err != nil || len(eIDs) == 0 {
 		return nil, err
 	}
@@ -21,9 +22,9 @@ func getEpisodeIDFromSeason(ctx context.Context, loaders *common.FilteredLoaders
 }
 
 // DefaultEpisodeID returns the default episode for the show
-func DefaultEpisodeID(ctx context.Context, loaders *common.FilteredLoaders, show *common.Show) (*int, error) {
+func DefaultEpisodeID(ctx context.Context, loaders *batchloaders.FilteredLoaders, show *common.Show) (*int, error) {
 	// TODO: this should respect continue watching as well, or previously shown episodes
-	sIDs, err := common.GetFromLoaderForKey(ctx, loaders.SeasonsLoader, show.ID)
+	sIDs, err := batchloaders.GetFromLoaderForKey(ctx, loaders.SeasonsLoader, show.ID)
 	if err != nil || len(sIDs) == 0 {
 		return nil, err
 	}

--- a/backend/items/show/loader.go
+++ b/backend/items/show/loader.go
@@ -1,6 +1,7 @@
 package show
 
 import (
+	"github.com/bcc-code/brunstadtv/backend/batchloaders"
 	"github.com/bcc-code/brunstadtv/backend/common"
 	"github.com/bcc-code/brunstadtv/backend/sqlc"
 	"github.com/graph-gophers/dataloader/v7"
@@ -8,12 +9,12 @@ import (
 
 // NewBatchLoader returns a configured batch loader for shows
 func NewBatchLoader(queries sqlc.Queries) *dataloader.Loader[int, *common.Show] {
-	return common.NewBatchLoader(queries.GetShows)
+	return batchloaders.NewBatchLoader(queries.GetShows)
 }
 
 // NewPermissionLoader returns a loader for permissions
 func NewPermissionLoader(queries sqlc.Queries) *dataloader.Loader[int, *common.Permissions[int]] {
-	return common.NewCustomBatchLoader(queries.GetPermissionsForShows, func(i common.Permissions[int]) int {
+	return batchloaders.NewCustomBatchLoader(queries.GetPermissionsForShows, func(i common.Permissions[int]) int {
 		return i.ItemID
 	})
 }

--- a/backend/search/indexing.go
+++ b/backend/search/indexing.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"context"
+	"github.com/bcc-code/brunstadtv/backend/batchloaders"
 	"strconv"
 	"strings"
 
@@ -117,7 +118,7 @@ func (service *Service) indexShow(ctx context.Context, id int) error {
 	if err != nil {
 		return err
 	}
-	p, err := common.GetFromLoaderByID(ctx, service.loaders.ShowPermissionLoader, id)
+	p, err := batchloaders.GetFromLoaderByID(ctx, service.loaders.ShowPermissionLoader, id)
 	if err != nil {
 		return err
 	}
@@ -141,7 +142,7 @@ func (service *Service) indexSeason(ctx context.Context, id int) error {
 	if err != nil {
 		return err
 	}
-	p, err := common.GetFromLoaderByID(ctx, service.loaders.SeasonPermissionLoader, id)
+	p, err := batchloaders.GetFromLoaderByID(ctx, service.loaders.SeasonPermissionLoader, id)
 	if err != nil {
 		return err
 	}
@@ -165,7 +166,7 @@ func (service *Service) indexEpisode(ctx context.Context, id int) error {
 	if err != nil {
 		return err
 	}
-	p, err := common.GetFromLoaderByID(ctx, service.loaders.EpisodePermissionLoader, id)
+	p, err := batchloaders.GetFromLoaderByID(ctx, service.loaders.EpisodePermissionLoader, id)
 	if err != nil {
 		return err
 	}
@@ -217,7 +218,7 @@ func indexCollection[k comparable, t indexable[k]](
 			return err
 		}
 
-		perm, err := common.GetFromLoaderByID(ctx, permissionLoader, i.GetKey())
+		perm, err := batchloaders.GetFromLoaderByID(ctx, permissionLoader, i.GetKey())
 		if err != nil {
 			return err
 		}

--- a/backend/search/service.go
+++ b/backend/search/service.go
@@ -3,6 +3,7 @@ package search
 import (
 	"database/sql"
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/bcc-code/brunstadtv/backend/batchloaders"
 	"github.com/bcc-code/brunstadtv/backend/common"
 	"github.com/bcc-code/brunstadtv/backend/items/episode"
 	"github.com/bcc-code/brunstadtv/backend/items/season"
@@ -68,7 +69,7 @@ func New(db *sql.DB, config Config) *Service {
 		ShowLoader:    show.NewBatchLoader(*service.queries),
 		SeasonLoader:  season.NewBatchLoader(*service.queries),
 		EpisodeLoader: episode.NewBatchLoader(*service.queries),
-		TagLoader:     common.NewBatchLoader(service.queries.GetTags),
+		TagLoader:     batchloaders.NewBatchLoader(service.queries.GetTags),
 		// Permissions
 		ShowPermissionLoader:    show.NewPermissionLoader(*service.queries),
 		SeasonPermissionLoader:  season.NewPermissionLoader(*service.queries),

--- a/backend/user/access.go
+++ b/backend/user/access.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"context"
+	"github.com/bcc-code/brunstadtv/backend/batchloaders"
 	"time"
 
 	"github.com/graph-gophers/dataloader/v7"
@@ -26,7 +27,7 @@ func ValidateAccess[k comparable](ctx context.Context, permissionLoader *dataloa
 	}
 	rs := GetRolesFromCtx(ginCtx)
 
-	perms, err := common.GetFromLoaderByID(ctx, permissionLoader, id)
+	perms, err := batchloaders.GetFromLoaderByID(ctx, permissionLoader, id)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Move batch loaders to a separate package.

Makes sense later if we add functionality, for less clutter.