### PR TITLE
Allow sending notifications to only members

### DIFF
--- a/backend/notifications/targets.go
+++ b/backend/notifications/targets.go
@@ -41,8 +41,8 @@ func (u *Utils) getTokensForGroups(ctx context.Context, codes []string) ([]commo
 	}
 	var personIDs []int
 	for _, g := range groups {
-		if g.Code == user.RoleBCCMember {
-			ids, err := u.queries.GetMemberIDs(ctx, true)
+		if g.Code == user.RoleBCCMember || g.Code == user.RoleRegistered {
+			ids, err := u.queries.GetMemberIDs(ctx, g.Code == user.RoleRegistered)
 			if err != nil {
 				return nil, err
 			}
@@ -64,6 +64,7 @@ func (u *Utils) getTokensForGroups(ctx context.Context, codes []string) ([]commo
 			}
 		}
 	}
+	personIDs = lo.Uniq(personIDs)
 	profiles, err := u.queries.GetProfilesForUserIDs(ctx, lo.Map(personIDs, func(i int, _ int) string {
 		return strconv.Itoa(i)
 	}))

--- a/backend/notifications/targets.go
+++ b/backend/notifications/targets.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"github.com/bcc-code/brunstadtv/backend/common"
 	"github.com/bcc-code/brunstadtv/backend/user"
-	"github.com/bcc-code/brunstadtv/backend/utils"
 	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"strconv"
@@ -39,16 +38,14 @@ func (u *Utils) getTokensForGroups(ctx context.Context, codes []string) ([]commo
 	if err != nil {
 		return nil, err
 	}
-	var personIDs []int
+	var personIDs []string
 	for _, g := range groups {
 		if g.Code == user.RoleBCCMember || g.Code == user.RoleRegistered {
 			ids, err := u.queries.GetMemberIDs(ctx, g.Code == user.RoleRegistered)
 			if err != nil {
 				return nil, err
 			}
-			personIDs = append(personIDs, lo.Map(ids, func(i string, _ int) int {
-				return utils.AsInt(i)
-			})...)
+			personIDs = append(personIDs, ids...)
 		}
 		// In case someone has been explicitly been granted the bcc-members role
 		if len(g.Emails) == 0 {
@@ -60,14 +57,12 @@ func (u *Utils) getTokensForGroups(ctx context.Context, codes []string) ([]commo
 		}
 		if users != nil {
 			for _, u := range *users {
-				personIDs = append(personIDs, u.PersonID)
+				personIDs = append(personIDs, strconv.Itoa(u.PersonID))
 			}
 		}
 	}
 	personIDs = lo.Uniq(personIDs)
-	profiles, err := u.queries.GetProfilesForUserIDs(ctx, lo.Map(personIDs, func(i int, _ int) string {
-		return strconv.Itoa(i)
-	}))
+	profiles, err := u.queries.GetProfilesForUserIDs(ctx, personIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/notifications/targets.go
+++ b/backend/notifications/targets.go
@@ -40,8 +40,8 @@ func (u *Utils) getTokensForGroups(ctx context.Context, codes []string) ([]commo
 	}
 	var personIDs []string
 	for _, g := range groups {
-		if g.Code == user.RoleBCCMember || g.Code == user.RoleRegistered {
-			ids, err := u.queries.GetMemberIDs(ctx, g.Code == user.RoleRegistered)
+		if everyone := g.Code == user.RoleRegistered; everyone || g.Code == user.RoleBCCMember {
+			ids, err := u.queries.GetMemberIDs(ctx, everyone)
 			if err != nil {
 				return nil, err
 			}

--- a/backend/sqlc/targets.sql.go
+++ b/backend/sqlc/targets.sql.go
@@ -13,8 +13,39 @@ import (
 	null_v4 "gopkg.in/guregu/null.v4"
 )
 
+const getMemberIDs = `-- name: GetMemberIDs :many
+SELECT u.id
+FROM users.users u
+WHERE u.active_bcc = $1
+`
+
+func (q *Queries) GetMemberIDs(ctx context.Context, activeBcc bool) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, getMemberIDs, activeBcc)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getTargets = `-- name: GetTargets :many
-WITH groups AS (SELECT targets_id, array_agg(usergroups_code)::varchar[] as codes FROM targets_usergroups GROUP BY targets_id)
+WITH groups AS (SELECT targets_id, array_agg(usergroups_code)::varchar[] as codes
+                FROM targets_usergroups
+                GROUP BY targets_id)
 SELECT t.id,
        t.label,
        t.type,

--- a/backend/sqlc/targets.sql.go
+++ b/backend/sqlc/targets.sql.go
@@ -16,11 +16,11 @@ import (
 const getMemberIDs = `-- name: GetMemberIDs :many
 SELECT u.id
 FROM users.users u
-WHERE u.active_bcc = $1
+WHERE $1::bool = true OR u.active_bcc
 `
 
-func (q *Queries) GetMemberIDs(ctx context.Context, activeBcc bool) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, getMemberIDs, activeBcc)
+func (q *Queries) GetMemberIDs(ctx context.Context, everyone bool) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, getMemberIDs, everyone)
 	if err != nil {
 		return nil, err
 	}

--- a/queries/targets.sql
+++ b/queries/targets.sql
@@ -1,5 +1,7 @@
 -- name: GetTargets :many
-WITH groups AS (SELECT targets_id, array_agg(usergroups_code)::varchar[] as codes FROM targets_usergroups GROUP BY targets_id)
+WITH groups AS (SELECT targets_id, array_agg(usergroups_code)::varchar[] as codes
+                FROM targets_usergroups
+                GROUP BY targets_id)
 SELECT t.id,
        t.label,
        t.type,
@@ -7,3 +9,8 @@ SELECT t.id,
 FROM targets t
          LEFT JOIN groups g ON g.targets_id = t.id
 WHERE id = ANY ($1::uuid[]);
+
+-- name: GetMemberIDs :many
+SELECT u.id
+FROM users.users u
+WHERE u.active_bcc = $1;

--- a/queries/targets.sql
+++ b/queries/targets.sql
@@ -13,4 +13,4 @@ WHERE id = ANY ($1::uuid[]);
 -- name: GetMemberIDs :many
 SELECT u.id
 FROM users.users u
-WHERE u.active_bcc = $1;
+WHERE @everyone::bool = true OR u.active_bcc;


### PR DESCRIPTION
Notifications can be filtered by the roles: bcc-members or registered. Registered will target everyone regardless of active membership and bcc-members will target every active member.