### PR TITLE
fix/completed-registration-cache allow polling this value

### DIFF
--- a/backend/auth0/userinfo.go
+++ b/backend/auth0/userinfo.go
@@ -36,3 +36,13 @@ type UserMetadata struct {
 	BirthYear       int  `json:"birth_year"`
 	MediaSubscriber bool `json:"media_subscriber"`
 }
+
+// CompletedRegistration returns true if the user has completed registration
+func (info UserInfo) CompletedRegistration() bool {
+	if completedRegistration, ok := info.UserMetadata["media_subscriber"]; ok {
+		if v, _ := completedRegistration.(bool); v {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/graph/api/resolver.go
+++ b/backend/graph/api/resolver.go
@@ -485,3 +485,14 @@ func (r *Resolver) updateMessage(ctx context.Context, id string, message *string
 	}
 	return id, err
 }
+
+func (r *Resolver) getUserInfo(ctx context.Context, userID string) (auth0.UserInfo, error) {
+	return memorycache.GetOrSet(ctx, "userinfo:"+userID, func(ctx context.Context) (auth0.UserInfo, error) {
+		ginCtx, _ := utils.GinCtx(ctx)
+		info, err := r.AuthClient.GetUser(ctx, ginCtx.GetString(auth0.CtxUserID))
+		if err != nil {
+			return auth0.UserInfo{}, err
+		}
+		return info, nil
+	}, cache.WithExpiration(time.Second*2))
+}

--- a/backend/graph/api/schema.resolvers.go
+++ b/backend/graph/api/schema.resolvers.go
@@ -601,14 +601,23 @@ func (r *userResolver) EmailVerified(ctx context.Context, obj *model.User) (bool
 	if obj.EmailVerified || obj.Anonymous || obj.ID == nil {
 		return obj.EmailVerified, nil
 	}
-	return memorycache.GetOrSet(ctx, "userinfo:email_verified:"+*obj.ID, func(ctx context.Context) (bool, error) {
-		ginCtx, _ := utils.GinCtx(ctx)
-		info, err := r.AuthClient.GetUser(ctx, ginCtx.GetString(auth0.CtxUserID))
-		if err != nil {
-			return false, err
-		}
-		return info.EmailVerified, nil
-	}, cache.WithExpiration(time.Second*2))
+	userinfo, err := r.getUserInfo(ctx, *obj.ID)
+	if err != nil {
+		return false, err
+	}
+	return userinfo.EmailVerified, nil
+}
+
+// CompletedRegistration is the resolver for the completedRegistration field.
+func (r *userResolver) CompletedRegistration(ctx context.Context, obj *model.User) (bool, error) {
+	if obj.CompletedRegistration || obj.Anonymous || obj.ID == nil {
+		return obj.EmailVerified, nil
+	}
+	userinfo, err := r.getUserInfo(ctx, *obj.ID)
+	if err != nil {
+		return false, err
+	}
+	return userinfo.CompletedRegistration(), nil
 }
 
 // QueryRoot returns generated.QueryRootResolver implementation.

--- a/backend/graph/api/schema/schema.graphqls
+++ b/backend/graph/api/schema/schema.graphqls
@@ -43,7 +43,7 @@ type User {
   gender: Gender!
   firstName: String!
   displayName: String!
-  completedRegistration: Boolean!
+  completedRegistration: Boolean! @goField(forceResolver: true)
 }
 
 input LegacyIDLookupOptions {

--- a/backend/user/middleware.go
+++ b/backend/user/middleware.go
@@ -244,11 +244,7 @@ func NewUserMiddleware(queries *sqlc.Queries, remoteCache *remotecache.Client, l
 					}
 					u.Age = time.Now().Year() - year
 				}
-				if completedRegistration, ok := info.UserMetadata["media_subscriber"]; ok {
-					if v, _ := completedRegistration.(bool); v {
-						u.CompletedRegistration = true
-					}
-				}
+				u.CompletedRegistration = info.CompletedRegistration()
 			}
 
 			if u.Email == "" {


### PR DESCRIPTION
Allow polling the completed-registration property on me. 

Will perhaps spam the auth0 api, but it has a per user limit of 1 per 2 seconds. Should survive this.