### PR TITLE
feat(player): allow overriding npaw metadata

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "packages/video-player/external-projects/videojs-chromecast"]
-	path = packages/video-player/external-projects/videojs-chromecast
-	url = https://github.com/bcc-code/videojs-chromecast
 [submodule "packages/video-player/external-projects/videojs-hls-quality-selector"]
 	path = packages/video-player/external-projects/videojs-hls-quality-selector
 	url = https://github.com/bcc-code/videojs-hls-quality-selector

--- a/packages/video-player/src/video-player/npaw.ts
+++ b/packages/video-player/src/video-player/npaw.ts
@@ -18,6 +18,7 @@ export type Options = {
             seasonTitle?: string,
             showTitle?: string,
             showId?: string,
+            overrides?: { [key: string]: string }
         },
     }
 }
@@ -39,6 +40,7 @@ function toConfig(options: Options) {
         "parse.manifest": true,
         "extraparam.1": options.tracking.sessionId,
         "extraparam.2": options.tracking.ageGroup,
+        ...md.overrides
     }
 }
 


### PR DESCRIPTION
I want to pipe the metadata straight from flutter to all 3 platforms so this would allow me to avoid mapping on the JS side